### PR TITLE
Try to fix zipaligning automated builds - explicit zipalign

### DIFF
--- a/project/vcmi-app/build.gradle
+++ b/project/vcmi-app/build.gradle
@@ -94,6 +94,7 @@ android {
     buildTypes {
         release {
             signingConfig signingConfigs.releaseSigning
+            zipAlignEnabled true
         }
     }
 


### PR DESCRIPTION
We need zipaligned apk before any signing performed if we want to re-sign for google play publishing