### PR TITLE
Fix campaigns by notifying vcmi-client that the server has stopped.

### DIFF
--- a/project/vcmi-app/src/main/java/eu/vcmi/vcmi/NativeMethods.java
+++ b/project/vcmi-app/src/main/java/eu/vcmi/vcmi/NativeMethods.java
@@ -34,6 +34,8 @@ public class NativeMethods
 
     public static native void notifyServerReady();
 
+    public static native void notifyServerClosed();
+
     public static native boolean tryToSaveTheGame();
 
     public static void setupCtx(final Context ctx)

--- a/project/vcmi-app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/project/vcmi-app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -677,6 +677,7 @@ public class SDLActivity extends ActivityBase
 
     private void initService()
     {
+        unbindServer();
         startService(new Intent(this, ServerService.class));
         bindService(new Intent(SDLActivity.this,
             ServerService.class), mServerServiceConnection, Context.BIND_AUTO_CREATE);
@@ -1357,11 +1358,11 @@ public class SDLActivity extends ActivityBase
 
     private static class IncomingServerMessageHandler extends Handler
     {
-        private WeakReference<IncomingServerMessageHandlerCallback> mCallbackRef;
+        private IncomingServerMessageHandlerCallback mCallback;
 
         IncomingServerMessageHandler(final IncomingServerMessageHandlerCallback callback)
         {
-            mCallbackRef = new WeakReference<>(callback);
+            mCallback = callback;
         }
 
         @Override
@@ -1374,11 +1375,11 @@ public class SDLActivity extends ActivityBase
                     NativeMethods.notifyServerReady();
                     break;
                 case SERVER_MESSAGE_SERVER_KILLED:
-                    final IncomingServerMessageHandlerCallback callback = mCallbackRef.get();
-                    if (callback != null)
+                    if (mCallback != null)
                     {
-                        callback.unbindServer();
+                        mCallback.unbindServer();
                     }
+                    NativeMethods.notifyServerClosed();
                     break;
                 default:
                     super.handleMessage(msg);
@@ -1395,5 +1396,3 @@ public class SDLActivity extends ActivityBase
         }
     }
 }
-
-


### PR DESCRIPTION
When winning the campaign there is a lock that waits for the old server to stop before allowing to continue with restarting the server. While the lock was released on PC builds as the server runs differently on Android this was missed making campaigns always hang the app when you win.

This commit makes sure we notify the client if the server stops so it can release the lock.

This commit also fixes the issue that the server's connection was never unbound, hence calling bind again did nothing. The main issue was that since the callback was created on the stack, but was only stored as a WeakReference it immediately became garbage collected, so the link to call unbind was gone.

This fixes the issue that you needed to restart the whole app every time you wanted to load or start a new game (and is required for campaigns to work as they also start a new game)

Requires https://github.com/vcmi/vcmi/pull/620 to be merged first

Build containing the fix (among others) can be found at https://github.com/sztupy/vcmi-android/releases