### PR TITLE
Fix clicking right mouse button handling as back

### DIFF
--- a/project/vcmi-app/src/main/java/org/libsdl/app/DummyEdit.java
+++ b/project/vcmi-app/src/main/java/org/libsdl/app/DummyEdit.java
@@ -70,18 +70,7 @@ class DummyEdit extends LinearLayout
                 return false;
             }
 
-            if (event.getAction() == KeyEvent.ACTION_DOWN)
-            {
-                SDLActivity.onNativeKeyDown(keyCode);
-                return false;
-            }
-            else if (event.getAction() == KeyEvent.ACTION_UP)
-            {
-                SDLActivity.onNativeKeyUp(keyCode);
-                return false;
-            }
-
-            return false;
+            return SDLActivity.mHolder.surface().onKey(v, keyCode, event);
         }
 
         //

--- a/project/vcmi-app/src/main/java/org/libsdl/app/SDLGenericMotionListener_API12.java
+++ b/project/vcmi-app/src/main/java/org/libsdl/app/SDLGenericMotionListener_API12.java
@@ -6,11 +6,13 @@ import android.view.View;
 
 class SDLGenericMotionListener_API12 implements View.OnGenericMotionListener
 {
+    private float x;
+    private float y;
+
     // Generic Motion (mouse hover, joystick...) events go here
     @Override
     public boolean onGenericMotion(View v, MotionEvent event)
     {
-        float x, y;
         int action;
 
         switch (event.getSource())
@@ -48,5 +50,15 @@ class SDLGenericMotionListener_API12 implements View.OnGenericMotionListener
 
         // Event was not managed
         return false;
+    }
+
+    public float getX()
+    {
+        return x;
+    }
+
+    public float getY()
+    {
+        return y;
     }
 }


### PR DESCRIPTION
Fix clicking right mouse button handling as back.
Since some Android version mouse right click is handled as back and is sent as key event but it is possible to distinguish it. Changes were made accordingly. They are not perfect so. GenericMotionListener tracks cursor position and when we receive back key from mouse we take these coordinates. They might be not precise enough. Tested on my Android 7.1 with bluetooth mouse emulated through Accross software.
Also fixed unhandled game exit when back is pressed after keyboard once appeared.